### PR TITLE
[EWT-2995] Optimize the performance of RTree search

### DIFF
--- a/src/kdtree/index.rs
+++ b/src/kdtree/index.rs
@@ -54,7 +54,7 @@ impl<N: IndexableNum> KDTreeMetadata<N> {
         let version = version_and_type >> 4;
         if version != KDBUSH_VERSION {
             return Err(GeoIndexError::General(
-                format!("Got v{} data when expected v{}.", version, KDBUSH_VERSION).to_string(),
+                format!("Got v{version} data when expected v{KDBUSH_VERSION}.").to_string(),
             ));
         }
 

--- a/src/rtree/index.rs
+++ b/src/rtree/index.rs
@@ -59,7 +59,7 @@ impl<N: IndexableNum> RTreeMetadata<N> {
         let version = version_and_type >> 4;
         if version != VERSION {
             return Err(GeoIndexError::General(
-                format!("Got v{} data when expected v{}.", version, VERSION).to_string(),
+                format!("Got v{version} data when expected v{VERSION}.").to_string(),
             ));
         }
 

--- a/src/type.rs
+++ b/src/type.rs
@@ -122,7 +122,7 @@ impl CoordType {
             u32::TYPE_INDEX => CoordType::UInt32,
             f32::TYPE_INDEX => CoordType::Float32,
             f64::TYPE_INDEX => CoordType::Float64,
-            t => return Err(GeoIndexError::General(format!("Unexpected type {}.", t))),
+            t => return Err(GeoIndexError::General(format!("Unexpected type {t}."))),
         };
         Ok(result)
     }


### PR DESCRIPTION
This PR contains several optimizations to improve the performance of searching an RTree:

* Avoid bounds checking when accessing boxes
* Use a single logical expression instead of 4 branching (improves performance on Apple M1 Pro, no effect on x86_64)
* Switch from DFS to BFS to have more friendly memory access pattern

Here are the benchmark results on different platforms. We included some new benchmarks in https://github.com/wherobots/geo-index/pull/3.

### x86_64 Linux

| Benchmark Name | Time (ms/µs) | Change (%) | Performance | Outliers (Total) | High Mild | High Severe | Low Mild | Low Severe |
|---|---|---|---|---|---|---|---|---|
| search\_buildings\_nodes\_hilbert\_f64 | 2.3390 - 2.4268 ms | -10.745 to -6.9617 | Improved | 9 (9.00%) | 1 | 8 | - | - |
| search\_buildings\_nodes\_str\_f64 | 2.8246 - 2.8489 ms | -7.5014 to -3.9446 | Improved | 11 (11.00%) | 2 | 9 | - | - |
| search\_buildings\_nodes\_hilbert\_f32 | 1.6623 - 1.7020 ms | -11.015 to -8.7392 | Improved | 5 (5.00%) | 1 | 4 | - | - |
| search\_buildings\_nodes\_str\_f32 | 1.6283 - 1.6391 ms | -9.9745 to -8.6808 | Improved | 7 (7.00%) | 4 | 3 | - | - |
| search\_postal\_codes\_buildings\_hilbert\_f64 | 374.06 - 378.47 µs | -16.490 to -13.542 | Improved | 8 (8.00%) | 2 | 6 | - | - |
| search\_postal\_codes\_buildings\_str\_f64 | 337.63 - 343.75 µs | -14.398 to -11.355 | Improved | 10 (10.00%) | 4 | 6 | - | - |
| search\_postal\_codes\_buildings\_hilbert\_f32 | 422.13 - 423.24 µs | -12.774 to -12.027 | Improved | 3 (3.00%) | 2 | 1 | - | - |
| search\_postal\_codes\_buildings\_str\_f32 | 391.60 - 399.73 µs | -8.1024 to -5.8440 | Improved | 12 (12.00%) | 2 | 10 | - | - |
| search\_buildings\_postal\_codes\_hilbert\_f64 | 563.15 - 574.50 ms | -1.8857 to +0.4872 | No Change | 17 (17.00%) | 2 | 3 | 4 | 8 |
| search\_buildings\_postal\_codes\_str\_f64 | 599.23 - 607.04 ms | -4.2089 to -2.5452 | Improved | 13 (13.00%) | 1 | - | 3 | 9 |
| search\_buildings\_postal\_codes\_hilbert\_f32 | 342.98 - 347.74 ms | -3.2167 to -1.5174 | Improved | 13 (13.00%) | 1 | 1 | 3 | 8 |
| search\_buildings\_postal\_codes\_str\_f32 | 370.54 - 375.16 ms | -7.8364 to -5.1512 | Improved | 12 (12.00%) | 1 | 1 | 7 | 3 |
| search (flatbush) | 728.03 - 733.26 µs | -11.051 to -5.1719 | Improved | 11 (11.00%) | 9 | 2 | - | - |
| search (flatbush STRTree) | 839.88 - 849.65 µs | -7.2130 to -6.4368 | Improved | 11 (11.00%) | 5 | 6 | - | - |
| search (flatbush f32) | 250.33 - 256.68 µs | -17.866 to -14.799 | Improved | 9 (9.00%) | 3 | 6 | - | - |
| search (rstar) | 1.5105 - 1.5218 ms | -2.8742 to -0.9492 | Noise Threshold | 9 (9.00%) | 3 | 5 | - | 1 |

### Apple M1 Pro macOS

| Benchmark Name | Time (ms/µs) | Change (%) | Performance | Outliers (Total) | High Mild | High Severe | Low Mild | Low Severe |
|---|---|---|---|---|---|---|---|---|
| search\_buildings\_nodes\_hilbert\_f64 | 756.84 - 791.37 µs | -31.608 to -29.827 | Improved | 8 (8.00%) | 4 | 4 | - | - |
| search\_buildings\_nodes\_str\_f64 | 746.03 - 765.55 µs | -24.477 to -22.749 | Improved | 12 (12.00%) | 6 | 6 | - | - |
| search\_buildings\_nodes\_hilbert\_f32 | 582.85 - 595.75 µs | -43.696 to -42.125 | Improved | 11 (11.00%) | 6 | 5 | - | - |
| search\_buildings\_nodes\_str\_f32 | 599.82 - 616.83 µs | -35.430 to -32.862 | Improved | - | - | - | - |
| search\_postal\_codes\_buildings\_hilbert\_f64 | 187.16 - 187.77 µs | -15.688 to -15.328 | Improved | 12 (12.00%) | 7 | 5 | - | - |
| search\_postal\_codes\_buildings\_str\_f64 | 179.75 - 180.35 µs | -11.377 to -10.636 | Improved | 6 (6.00%) | 5 | 1 | - | - |
| search\_postal\_codes\_buildings\_hilbert\_f32 | 193.27 - 194.30 µs | -25.161 to -24.474 | Improved | 6 (6.00%) | 6 | - | - | - |
| search\_postal\_codes\_buildings\_str\_f32 | 187.92 - 188.50 µs | -21.658 to -20.967 | Improved | 10 (10.00%) | 7 | 3 | - | - |
| search\_buildings\_postal\_codes\_hilbert\_f64 | 59.698 - 62.120 ms | -31.342 to -27.588 | Improved | 18 (18.00%) | 15 | 3 | - | - |
| search\_buildings\_postal\_codes\_str\_f64 | 71.386 - 73.413 ms | -25.727 to -22.296 | Improved | 6 (6.00%) | 6 | - | - | - |
| search\_buildings\_postal\_codes\_hilbert\_f32 | 50.480 - 51.362 ms | -34.196 to -32.696 | Improved | 13 (13.00%) | - | 3 | 9 | 1 |
| search\_buildings\_postal\_codes\_str\_f32 | 59.983 - 60.593 ms | -32.580 to -31.576 | Improved | 9 (9.00%) | 1 | - | 8 | - |
| search (flatbush) | 87.538 - 88.604 µs | -21.663 to -20.281 | Improved | - | - | - | - |
| search (flatbush STRTree) | 91.037 - 92.492 µs | -21.287 to -19.429 | Improved | 1 (1.00%) | - | 1 | - | - |
| search (flatbush f32) | 80.236 - 81.380 µs | -26.939 to -25.508 | Improved | - | - | - | - |
| search (rstar) | 171.88 - 174.55 µs | +0.9157 to +3.9126 | Noise Threshold | 23 (23.00%) | 7 | 2 | 5 | 9 |

