### PR TITLE
[EXPERIMENTAL] Software prefetching

### DIFF
--- a/src/kdtree/index.rs
+++ b/src/kdtree/index.rs
@@ -54,7 +54,7 @@ impl<N: IndexableNum> KDTreeMetadata<N> {
         let version = version_and_type >> 4;
         if version != KDBUSH_VERSION {
             return Err(GeoIndexError::General(
-                format!("Got v{} data when expected v{}.", version, KDBUSH_VERSION).to_string(),
+                format!("Got v{version} data when expected v{KDBUSH_VERSION}.").to_string(),
             ));
         }
 

--- a/src/rtree/index.rs
+++ b/src/rtree/index.rs
@@ -59,7 +59,7 @@ impl<N: IndexableNum> RTreeMetadata<N> {
         let version = version_and_type >> 4;
         if version != VERSION {
             return Err(GeoIndexError::General(
-                format!("Got v{} data when expected v{}.", version, VERSION).to_string(),
+                format!("Got v{version} data when expected v{VERSION}.").to_string(),
             ));
         }
 

--- a/src/type.rs
+++ b/src/type.rs
@@ -122,7 +122,7 @@ impl CoordType {
             u32::TYPE_INDEX => CoordType::UInt32,
             f32::TYPE_INDEX => CoordType::Float32,
             f64::TYPE_INDEX => CoordType::Float64,
-            t => return Err(GeoIndexError::General(format!("Unexpected type {}.", t))),
+            t => return Err(GeoIndexError::General(format!("Unexpected type {t}."))),
         };
         Ok(result)
     }


### PR DESCRIPTION
This patch is based on https://github.com/wherobots/geo-index/pull/2. We add software prefetching to prefetch the internal node that we'll read in the next round to hide the latency of reading the internal node into CPU's cache.

The benchmark result is interesting.

### Apple M1 Pro

It shows 10% performance improvement on the buildings X nodes benchmark, but has performance regression on all other benchmarks. This is probably because buildings is large enough for search to stall on memory loading, while other benchmarks searches smaller indexes, the internal nodes could fit in L2/L3 CPU caches so the overhead of prefetching does not out weight the benefit.

| Benchmark Name | Time | Change | Performance |
|---|---|---|---|
| search (flatbush) | [73.332 µs 76.151 µs 79.141 µs] | [+2.4795% +6.7823% +10.804%] | Performance has regressed. |
| search (flatbush STRTree) | [75.625 µs 77.319 µs 79.341 µs] | [+9.8115% +13.341% +16.657%] | Performance has regressed. |
| search (flatbush f32) | [68.342 µs 70.280 µs 72.425 µs] | [-2.1377% +1.5237% +5.2104%] | No change in performance detected. |
| search (rstar) | [155.73 µs 156.88 µs 158.04 µs] | [-2.0575% -1.2146% -0.3402%] | Change within noise threshold. |
| **search\_buildings\_nodes\_hilbert\_f64** | [617.44 µs 626.78 µs 641.94 µs] | **[-16.377% -15.240% -13.962%]** | Performance has improved. |
| **search\_buildings\_nodes\_str\_f64** | [585.55 µs 589.69 µs 593.82 µs] | **[-24.003% -22.088% -20.673%]** | Performance has improved. |
| **search\_buildings\_nodes\_hilbert\_f32** | [524.10 µs 530.27 µs 537.00 µs] | **[-10.418% -9.1960% -7.8536%]** | Performance has improved. |
| **search\_buildings\_nodes\_str\_f32** | [505.52 µs 511.27 µs 518.01 µs] | **[-14.817% -13.715% -12.629%]** | Performance has improved. |
| search\_postal\_codes\_buildings\_hilbert\_f64 | [191.79 µs 192.10 µs 192.43 µs] | [+2.3092% +2.5467% +2.7876%] | Performance has regressed. |
| search\_postal\_codes\_buildings\_str\_f64 | [184.65 µs 185.49 µs 187.01 µs] | [+2.4167% +2.8413% +3.5412%] | Performance has regressed. |
| search\_postal\_codes\_buildings\_hilbert\_f32 | [196.26 µs 196.54 µs 196.84 µs] | [+1.8956% +2.1742% +2.4667%] | Performance has regressed. |
| search\_postal\_codes\_buildings\_str\_f32 | [189.73 µs 190.03 µs 190.37 µs] | [+1.6782% +1.8969% +2.1075%] | Performance has regressed. |
| search\_buildings\_postal\_codes\_hilbert\_f64 | [81.743 ms 82.343 ms 82.921 ms] | [+11.360% +13.406% +15.624%] | Performance has regressed. |
| search\_buildings\_postal\_codes\_str\_f64 | [85.409 ms 87.121 ms 88.813 ms] | [+18.308% +21.124% +23.888%] | Performance has regressed. |
| search\_buildings\_postal\_codes\_hilbert\_f32 | [50.703 ms 50.986 ms 51.254 ms] | [-0.8144% +0.0378% +0.8444%] | No change in performance detected. |
| search\_buildings\_postal\_codes\_str\_f32 | [61.825 ms 62.129 ms 62.428 ms] | [+2.5681% +3.2736% +3.9868%] | Performance has regressed. |

### x86_64

Performance became worse, even for the buildings X nodes benchmark.

| Benchmark Name | Time | Change | Performance |
|---|---|---|---|
| search\_buildings\_nodes\_hilbert\_f64 | [2.3860 ms 2.4014 ms 2.4264 ms] | [+2.3152% +2.8958% +3.5300%] | Performance has regressed. |
| search\_buildings\_nodes\_str\_f64 | [2.9108 ms 2.9300 ms 2.9622 ms] | [+3.5537% +4.1180% +4.8419%] | Performance has regressed. |
| search\_buildings\_nodes\_hilbert\_f32 | [1.6602 ms 1.6663 ms 1.6748 ms] | [-0.9394% +0.0974% +1.3484%] | No change in performance detected. |
| search\_buildings\_nodes\_str\_f32 | [1.7263 ms 1.7311 ms 1.7363 ms] | [+0.5968% +1.6457% +2.8079%] | Change within noise threshold. |
| search\_postal\_codes\_buildings\_hilbert\_f64 | [408.61 µs 410.39 µs 413.05 µs] | [+7.3265% +8.5911% +9.6543%] | Performance has regressed. |
| search\_postal\_codes\_buildings\_str\_f64 | [375.94 µs 381.64 µs 388.50 µs] | [+10.313% +11.791% +13.428%] | Performance has regressed. |
| search\_postal\_codes\_buildings\_hilbert\_f32 | [450.80 µs 454.88 µs 460.06 µs] | [+6.0544% +6.8311% +7.7563%] | Performance has regressed. |
| search\_postal\_codes\_buildings\_str\_f32 | [419.96 µs 422.15 µs 425.51 µs] | [+5.5079% +6.1386% +6.9293%] | Performance has regressed. |
| search\_buildings\_postal\_codes\_hilbert\_f64 | [551.07 ms 555.31 ms 559.29 ms] | [-4.1941% -2.9699% -1.8463%] | Performance has improved. |
| search\_buildings\_postal\_codes\_str\_f64 | [583.61 ms 587.47 ms 591.01 ms] | [-7.0304% -5.9931% -4.9347%] | Performance has improved. |
| search\_buildings\_postal\_codes\_hilbert\_f32 | [336.71 ms 339.85 ms 343.19 ms] | [-1.6602% -0.6754% +0.3478%] | No change in performance detected. |
| search\_buildings\_postal\_codes\_str\_f32 | [363.93 ms 367.20 ms 370.66 ms] | [-2.8347% -1.8728% -0.8794%] | Change within noise threshold. |

### Conclusion

The effectiveness of software prefetching is highly dependent on the specific CPU architecture and the memory access patterns of the benchmark. Further investigation is needed to understand the underlying reasons for the performance degradation on x86_64 and to explore more adaptive or architecture-specific prefetching strategies.