### PR TITLE
[EWT-2847] Implement geometry-based distance calculations based on geo crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ categories = ["data-structures", "algorithms", "science::geo"]
 [dependencies]
 bytemuck = "1"
 float_next_after = "1"
+geo = "0.30.0"
 geo-traits = "0.3"
 geo-types = "0.7.16"
 num-traits = "0.2"
@@ -25,7 +26,6 @@ wkt = "0.14.0"
 
 [dev-dependencies]
 criterion = { version = "0.5", features = ["html_reports"] }
-geo = "0.30.0"
 geozero = "0.12"
 rstar = "0.12"
 zip = "2.2.2"
@@ -39,3 +39,13 @@ harness = false
 [[bench]]
 name = "real_world_case"
 harness = false
+
+[[bench]]
+name = "distance"
+harness = false
+
+[[example]]
+name = "distance_metrics"
+
+[[example]]
+name = "geometry_neighbors"

--- a/benches/distance.rs
+++ b/benches/distance.rs
@@ -1,0 +1,240 @@
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use geo::{Geometry, LineString, Point, Polygon};
+use geo_index::rtree::distance::{
+    DistanceMetric, EuclideanDistance, HaversineDistance, SpheroidDistance,
+};
+use geo_index::rtree::sort::HilbertSort;
+use geo_index::rtree::{RTreeBuilder, RTreeIndex};
+use geo_types::coord;
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+fn generate_test_data(n: usize) -> (Vec<Point<f64>>, Vec<Geometry<f64>>) {
+    let mut rng = StdRng::seed_from_u64(42);
+    let mut points = Vec::with_capacity(n);
+    let mut geometries = Vec::with_capacity(n);
+
+    for i in 0..n {
+        let x = rng.gen_range(-180.0..180.0);
+        let y = rng.gen_range(-90.0..90.0);
+        let point = Point::new(x, y);
+        points.push(point);
+
+        // Create a mix of geometry types
+        let geom = match i % 3 {
+            0 => Geometry::Point(point),
+            1 => {
+                // Create a small line around the point
+                let offset = 0.01;
+                Geometry::LineString(LineString::new(vec![
+                    coord! { x: x, y: y },
+                    coord! { x: x + offset, y: y + offset },
+                ]))
+            }
+            2 => {
+                // Create a small square around the point
+                let offset = 0.005;
+                Geometry::Polygon(Polygon::new(
+                    LineString::new(vec![
+                        coord! { x: x - offset, y: y - offset },
+                        coord! { x: x + offset, y: y - offset },
+                        coord! { x: x + offset, y: y + offset },
+                        coord! { x: x - offset, y: y + offset },
+                        coord! { x: x - offset, y: y - offset },
+                    ]),
+                    vec![],
+                ))
+            }
+            _ => unreachable!(),
+        };
+        geometries.push(geom);
+    }
+
+    (points, geometries)
+}
+
+fn build_rtree(points: &[Point<f64>]) -> geo_index::rtree::RTree<f64> {
+    let mut builder = RTreeBuilder::new(points.len() as u32);
+    for point in points {
+        builder.add(point.x(), point.y(), point.x(), point.y());
+    }
+    builder.finish::<HilbertSort>()
+}
+
+fn benchmark_distance_metrics(c: &mut Criterion) {
+    let sizes = vec![100, 1000];
+
+    for size in sizes {
+        let (points, geometries) = generate_test_data(size);
+        let tree = build_rtree(&points);
+        let query_point = Point::new(0.0, 0.0);
+
+        let euclidean = EuclideanDistance;
+        let haversine = HaversineDistance::default();
+        let spheroid = SpheroidDistance::default();
+
+        // Benchmark neighbors_with_distance with different metrics
+        let mut group = c.benchmark_group("neighbors_with_distance");
+
+        group.bench_with_input(BenchmarkId::new("euclidean", size), &size, |b, _| {
+            b.iter(|| {
+                tree.neighbors_with_distance(
+                    query_point.x(),
+                    query_point.y(),
+                    Some(10),
+                    None,
+                    &euclidean,
+                )
+            })
+        });
+
+        group.bench_with_input(BenchmarkId::new("haversine", size), &size, |b, _| {
+            b.iter(|| {
+                tree.neighbors_with_distance(
+                    query_point.x(),
+                    query_point.y(),
+                    Some(10),
+                    None,
+                    &haversine,
+                )
+            })
+        });
+
+        group.bench_with_input(BenchmarkId::new("spheroid", size), &size, |b, _| {
+            b.iter(|| {
+                tree.neighbors_with_distance(
+                    query_point.x(),
+                    query_point.y(),
+                    Some(10),
+                    None,
+                    &spheroid,
+                )
+            })
+        });
+
+        group.finish();
+
+        // Benchmark neighbors_geometry with different metrics
+        let mut geom_group = c.benchmark_group("neighbors_geometry");
+        let query_geometry = Geometry::Point(query_point);
+
+        geom_group.bench_with_input(BenchmarkId::new("euclidean", size), &size, |b, _| {
+            b.iter(|| {
+                tree.neighbors_geometry(&query_geometry, Some(10), None, &euclidean, &geometries)
+            })
+        });
+
+        geom_group.bench_with_input(BenchmarkId::new("haversine", size), &size, |b, _| {
+            b.iter(|| {
+                tree.neighbors_geometry(&query_geometry, Some(10), None, &haversine, &geometries)
+            })
+        });
+
+        geom_group.bench_with_input(BenchmarkId::new("spheroid", size), &size, |b, _| {
+            b.iter(|| {
+                tree.neighbors_geometry(&query_geometry, Some(10), None, &spheroid, &geometries)
+            })
+        });
+
+        geom_group.finish();
+    }
+}
+
+fn benchmark_distance_calculations(c: &mut Criterion) {
+    let euclidean = EuclideanDistance;
+    let haversine = HaversineDistance::default();
+    let spheroid = SpheroidDistance::default();
+
+    let p1 = Point::new(-74.0, 40.7); // New York
+    let p2 = Point::new(-0.1, 51.5); // London
+    let geom1 = Geometry::Point(p1);
+    let geom2 = Geometry::Point(p2);
+
+    // Benchmark raw distance calculations
+    let mut group = c.benchmark_group("distance_calculation");
+
+    group.bench_function("euclidean_point_to_point", |b| {
+        b.iter(|| euclidean.distance(p1.x(), p1.y(), p2.x(), p2.y()))
+    });
+
+    group.bench_function("haversine_point_to_point", |b| {
+        b.iter(|| haversine.distance(p1.x(), p1.y(), p2.x(), p2.y()))
+    });
+
+    group.bench_function("spheroid_point_to_point", |b| {
+        b.iter(|| spheroid.distance(p1.x(), p1.y(), p2.x(), p2.y()))
+    });
+
+    group.bench_function("euclidean_geometry_to_geometry", |b| {
+        b.iter(|| {
+            let _: f64 = euclidean.geometry_to_geometry_distance(&geom1, &geom2);
+        })
+    });
+
+    group.bench_function("haversine_geometry_to_geometry", |b| {
+        b.iter(|| {
+            let _: f64 = haversine.geometry_to_geometry_distance(&geom1, &geom2);
+        })
+    });
+
+    group.bench_function("spheroid_geometry_to_geometry", |b| {
+        b.iter(|| {
+            let _: f64 = spheroid.geometry_to_geometry_distance(&geom1, &geom2);
+        })
+    });
+
+    // Benchmark bbox distance calculations
+    let bbox = (-75.0, 40.0, -73.0, 41.0); // Bbox around New York
+
+    group.bench_function("euclidean_distance_to_bbox", |b| {
+        b.iter(|| euclidean.distance_to_bbox(p2.x(), p2.y(), bbox.0, bbox.1, bbox.2, bbox.3))
+    });
+
+    group.bench_function("haversine_distance_to_bbox", |b| {
+        b.iter(|| haversine.distance_to_bbox(p2.x(), p2.y(), bbox.0, bbox.1, bbox.2, bbox.3))
+    });
+
+    group.bench_function("spheroid_distance_to_bbox", |b| {
+        b.iter(|| spheroid.distance_to_bbox(p2.x(), p2.y(), bbox.0, bbox.1, bbox.2, bbox.3))
+    });
+
+    group.finish();
+}
+
+fn benchmark_comparison_with_baseline(c: &mut Criterion) {
+    let (points, _) = generate_test_data(1000);
+    let tree = build_rtree(&points);
+    let query_point = Point::new(0.0, 0.0);
+
+    let euclidean = EuclideanDistance;
+
+    let mut group = c.benchmark_group("baseline_comparison");
+
+    // Original neighbors method (baseline)
+    group.bench_function("original_neighbors", |b| {
+        b.iter(|| tree.neighbors(query_point.x(), query_point.y(), Some(10), None))
+    });
+
+    // New neighbors_with_distance method
+    group.bench_function("neighbors_with_distance_euclidean", |b| {
+        b.iter(|| {
+            tree.neighbors_with_distance(
+                query_point.x(),
+                query_point.y(),
+                Some(10),
+                None,
+                &euclidean,
+            )
+        })
+    });
+
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    benchmark_distance_metrics,
+    benchmark_distance_calculations,
+    benchmark_comparison_with_baseline
+);
+criterion_main!(benches);

--- a/examples/distance_metrics.rs
+++ b/examples/distance_metrics.rs
@@ -93,9 +93,7 @@ fn spheroid_distance_example() {
         tree.neighbors_with_distance(query_point.0, query_point.1, Some(3), None, &spheroid);
 
     println!("  Nearest neighbors (by insertion order): {:?}", results);
-    println!("  Distance metric: Spheroid (distance on ellipsoid)");
-    println!("  Semi-major axis: {} meters", spheroid.semi_major_axis);
-    println!("  Semi-minor axis: {} meters", spheroid.semi_minor_axis);
+    println!("  Distance metric: Spheroid (distance on ellipsoid using Geodesic calculations)");
 }
 
 fn comparison_example() {

--- a/examples/geometry_neighbors.rs
+++ b/examples/geometry_neighbors.rs
@@ -1,0 +1,158 @@
+//! Example demonstrating geometry-based neighbor search.
+//!
+//! This example shows how to use the neighbors_geometry method to find
+//! nearest neighbors based on actual geometry distances rather than just
+//! bounding box distances.
+
+use geo::algorithm::BoundingRect;
+use geo::{Geometry, LineString, Point, Polygon};
+use geo_index::rtree::distance::EuclideanDistance;
+use geo_index::rtree::sort::HilbertSort;
+use geo_index::rtree::{RTreeBuilder, RTreeIndex};
+use geo_types::coord;
+
+fn main() {
+    println!("=== Geometry-based Neighbor Search Example ===\n");
+
+    // Example 1: Point geometries
+    println!("1. Finding nearest point geometries:");
+    point_geometries_example();
+
+    // Example 2: Mixed geometry types
+    println!("\n2. Finding nearest geometries with mixed types:");
+    mixed_geometries_example();
+
+    // Example 3: LineString geometries
+    println!("\n3. Finding nearest line geometries:");
+    linestring_geometries_example();
+}
+
+fn point_geometries_example() {
+    let mut builder = RTreeBuilder::<f64>::new(5);
+
+    // Create bounding boxes for the points
+    let points = vec![
+        Point::new(1.0, 1.0),
+        Point::new(4.0, 2.0),
+        Point::new(2.0, 5.0),
+        Point::new(7.0, 3.0),
+        Point::new(5.0, 6.0),
+    ];
+
+    // Add bounding boxes to the spatial index
+    for point in points.iter() {
+        builder.add(point.x(), point.y(), point.x(), point.y());
+    }
+    let tree = builder.finish::<HilbertSort>();
+
+    // Create geometries array
+    let geometries: Vec<Geometry<f64>> = points.into_iter().map(|p| Geometry::Point(p)).collect();
+
+    // Query with a point geometry
+    let query_geom = Geometry::Point(Point::new(3.0, 3.0));
+    let euclidean = EuclideanDistance;
+    let results = tree.neighbors_geometry(&query_geom, Some(3), None, &euclidean, &geometries);
+
+    println!("  Query point: (3.0, 3.0)");
+    println!("  Nearest 3 points (indices): {:?}", results);
+
+    for (rank, &idx) in results.iter().enumerate() {
+        if let Geometry::Point(p) = &geometries[idx as usize] {
+            println!("    {}. Point at ({}, {})", rank + 1, p.x(), p.y());
+        }
+    }
+}
+
+fn mixed_geometries_example() {
+    let mut builder = RTreeBuilder::<f64>::new(4);
+
+    // Create mixed geometries and their bounding boxes
+    let geometries = vec![
+        // Point at origin
+        Geometry::Point(Point::new(0.0, 0.0)),
+        // Horizontal line
+        Geometry::LineString(LineString::new(vec![
+            coord! { x: 2.0, y: 2.0 },
+            coord! { x: 6.0, y: 2.0 },
+        ])),
+        // Square polygon
+        Geometry::Polygon(Polygon::new(
+            LineString::new(vec![
+                coord! { x: 5.0, y: 5.0 },
+                coord! { x: 8.0, y: 5.0 },
+                coord! { x: 8.0, y: 8.0 },
+                coord! { x: 5.0, y: 8.0 },
+                coord! { x: 5.0, y: 5.0 },
+            ]),
+            vec![],
+        )),
+        // Another point
+        Geometry::Point(Point::new(10.0, 1.0)),
+    ];
+
+    // Add bounding boxes to the spatial index
+    for geom in &geometries {
+        if let Some(rect) = geom.bounding_rect() {
+            let min = rect.min();
+            let max = rect.max();
+            builder.add(min.x, min.y, max.x, max.y);
+        }
+    }
+    let tree = builder.finish::<HilbertSort>();
+
+    // Query with a point near the line
+    let query_geom = Geometry::Point(Point::new(4.0, 3.0));
+    let euclidean = EuclideanDistance;
+    let results = tree.neighbors_geometry(&query_geom, None, None, &euclidean, &geometries);
+
+    println!("  Query point: (4.0, 3.0)");
+    println!("  Nearest geometries (indices): {:?}", results);
+
+    for (rank, &idx) in results.iter().enumerate() {
+        match &geometries[idx as usize] {
+            Geometry::Point(p) => println!("    {}. Point at ({}, {})", rank + 1, p.x(), p.y()),
+            Geometry::LineString(_) => println!("    {}. LineString", rank + 1),
+            Geometry::Polygon(_) => println!("    {}. Polygon", rank + 1),
+            _ => println!("    {}. Other geometry", rank + 1),
+        }
+    }
+}
+
+fn linestring_geometries_example() {
+    let mut builder = RTreeBuilder::<f64>::new(3);
+
+    // Create line geometries
+    let lines = vec![
+        // Horizontal line at y=0
+        LineString::new(vec![coord! { x: 0.0, y: 0.0 }, coord! { x: 10.0, y: 0.0 }]),
+        // Vertical line at x=5
+        LineString::new(vec![coord! { x: 5.0, y: 0.0 }, coord! { x: 5.0, y: 10.0 }]),
+        // Diagonal line
+        LineString::new(vec![coord! { x: 0.0, y: 0.0 }, coord! { x: 10.0, y: 10.0 }]),
+    ];
+
+    // Add bounding boxes to the spatial index
+    for line in &lines {
+        if let Some(rect) = line.bounding_rect() {
+            let min = rect.min();
+            let max = rect.max();
+            builder.add(min.x, min.y, max.x, max.y);
+        }
+    }
+    let tree = builder.finish::<HilbertSort>();
+
+    // Create geometries array
+    let geometries: Vec<Geometry<f64>> =
+        lines.into_iter().map(|l| Geometry::LineString(l)).collect();
+
+    // Query with a point
+    let query_geom = Geometry::Point(Point::new(3.0, 1.0));
+    let euclidean = EuclideanDistance;
+    let results = tree.neighbors_geometry(&query_geom, None, None, &euclidean, &geometries);
+
+    println!("  Query point: (3.0, 1.0)");
+    println!("  Nearest lines (indices): {:?}", results);
+    println!("  Line 0: Horizontal line at y=0 (closest to query point)");
+    println!("  Line 1: Vertical line at x=5");
+    println!("  Line 2: Diagonal line");
+}

--- a/python/Cargo.lock
+++ b/python/Cargo.lock
@@ -26,6 +26,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android-tzdata"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -305,6 +311,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -439,6 +451,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "earcutr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79127ed59a85d7687c409e9978547cffb7dc79675355ed22da6b66fd5f6ead01"
+dependencies = [
+ "itertools",
+ "num-traits",
+]
+
+[[package]]
 name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -467,36 +489,74 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "geo"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4416397671d8997e9a3e7ad99714f4f00a22e9eaa9b966a5985d2194fc9e02e1"
+dependencies = [
+ "earcutr",
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "i_overlay",
+ "log",
+ "num-traits",
+ "robust",
+ "rstar",
+ "spade",
+]
+
+[[package]]
 name = "geo-index"
-version = "0.2.0"
+version = "0.3.1"
 dependencies = [
  "bytemuck",
  "float_next_after",
+ "geo",
  "geo-traits",
+ "geo-types",
  "num-traits",
  "rayon",
  "thiserror",
  "tinyvec",
+ "wkt",
 ]
 
 [[package]]
 name = "geo-traits"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b018fc19fa58202b03f1c809aebe654f7d70fd3887dace34c3d05c11aeb474b5"
+checksum = "2e7c353d12a704ccfab1ba8bfb1a7fe6cb18b665bf89d37f4f7890edcd260206"
 dependencies = [
  "geo-types",
 ]
 
 [[package]]
 name = "geo-types"
-version = "0.7.14"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6f47c611187777bbca61ea7aba780213f5f3441fd36294ab333e96cfa791b65"
+checksum = "75a4dcd69d35b2c87a7c83bce9af69fd65c9d68d3833a0ded568983928f3fc99"
 dependencies = [
  "approx",
  "num-traits",
+ "rayon",
+ "rstar",
  "serde",
+]
+
+[[package]]
+name = "geographiclib-rs"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f611040a2bb37eaa29a78a128d1e92a378a03e0b6e66ae27398d42b1ba9a7841"
+dependencies = [
+ "libm",
 ]
 
 [[package]]
@@ -539,16 +599,84 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "i_float"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85df3a416829bb955fdc2416c7b73680c8dcea8d731f2c7aa23e1042fe1b8343"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "i_key_sort"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "347c253b4748a1a28baf94c9ce133b6b166f08573157e05afe718812bc599fcd"
+
+[[package]]
+name = "i_overlay"
+version = "2.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0542dfef184afdd42174a03dcc0625b6147fb73e1b974b1a08a2a42ac35cee49"
+dependencies = [
+ "i_float",
+ "i_key_sort",
+ "i_shape",
+ "i_tree",
+ "rayon",
+]
+
+[[package]]
+name = "i_shape"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a38f5a42678726718ff924f6d4a0e79b129776aeed298f71de4ceedbd091bce"
+dependencies = [
+ "i_float",
+ "serde",
+]
+
+[[package]]
+name = "i_tree"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "155181bc97d770181cf9477da51218a19ee92a8e5be642e796661aee2b601139"
 
 [[package]]
 name = "iana-time-zone"
@@ -588,6 +716,15 @@ name = "indoc"
 version = "2.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+
+[[package]]
+name = "itertools"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1c173a5686ce8bfa551b3563d0c2170bf24ca44da99c7ca4bfdab5418c3fe57"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -1064,6 +1201,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1133,6 +1287,30 @@ name = "siphasher"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "spade"
+version = "2.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a14e31a007e9f85c32784b04f89e6e194bb252a4d41b4a8ccd9e77245d901c8c"
+dependencies = [
+ "hashbrown",
+ "num-traits",
+ "robust",
+ "smallvec",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -1351,6 +1529,19 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wkt"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "efb2b923ccc882312e559ffaa832a055ba9d1ac0cc8e86b3e25453247e4b81d7"
+dependencies = [
+ "geo-traits",
+ "geo-types",
+ "log",
+ "num-traits",
+ "thiserror",
+]
 
 [[package]]
 name = "zerocopy"

--- a/python/python/geoindex_rs/__init__.py
+++ b/python/python/geoindex_rs/__init__.py
@@ -1,4 +1,13 @@
 from ._rust import kdtree, rtree
 from ._rust import ___version
+from .enums import DistanceMetric, RTreeMethod
 
 __version__: str = ___version()
+
+__all__ = [
+    "kdtree",
+    "rtree", 
+    "DistanceMetric",
+    "RTreeMethod",
+    "__version__",
+]

--- a/python/python/geoindex_rs/enums.py
+++ b/python/python/geoindex_rs/enums.py
@@ -24,3 +24,31 @@ class RTreeMethod(StrEnum):
     STR = auto()
     """Use the Sort-Tile-Recursive algorithm for sorting the RTree
     """
+
+
+class DistanceMetric(StrEnum):
+    Euclidean = auto()
+    """Euclidean distance metric for planar coordinates.
+    
+    This is the standard straight-line distance calculation suitable for
+    planar coordinate systems. When working with longitude/latitude coordinates,
+    the unit of distance will be degrees.
+    """
+
+    Haversine = auto()
+    """Haversine distance metric for geographic coordinates.
+    
+    This calculates the great-circle distance between two points on a sphere.
+    It's more accurate for geographic distances than Euclidean distance.
+    The input coordinates should be in longitude/latitude (degrees), and
+    the output distance is in meters.
+    """
+
+    Spheroid = auto()
+    """Spheroid distance metric for high-precision geographic coordinates.
+    
+    This calculates the shortest distance between two points on the surface
+    of a spheroid (ellipsoid), providing a more accurate Earth model than
+    a simple sphere. The input coordinates should be in longitude/latitude
+    (degrees), and the output distance is in meters.
+    """

--- a/python/src/rtree/mod.rs
+++ b/python/src/rtree/mod.rs
@@ -24,9 +24,11 @@ pub fn register_rtree_module(
     child_module.add_class::<builder::PyRTree>()?;
     child_module.add_class::<builder::PyRTreeBuilder>()?;
     child_module.add_class::<metadata::PyRTreeMetadata>()?;
+    child_module.add_class::<neighbors::PyDistanceMetric>()?;
     child_module.add_wrapped(wrap_pyfunction!(boxes_at_level::boxes_at_level))?;
     child_module.add_wrapped(wrap_pyfunction!(intersection::tree_join))?;
     child_module.add_wrapped(wrap_pyfunction!(neighbors::neighbors))?;
+    child_module.add_wrapped(wrap_pyfunction!(neighbors::neighbors_with_distance))?;
     child_module.add_wrapped(wrap_pyfunction!(partitions::partition_boxes))?;
     child_module.add_wrapped(wrap_pyfunction!(partitions::partitions))?;
     child_module.add_wrapped(wrap_pyfunction!(search::search))?;

--- a/python/src/rtree/neighbors.rs
+++ b/python/src/rtree/neighbors.rs
@@ -13,11 +13,8 @@ use crate::rtree::input::PyRTreeRef;
 #[pyclass(eq, eq_int)]
 #[derive(PartialEq, Eq)]
 pub enum PyDistanceMetric {
-    #[pyo3(name = "euclidean")]
     Euclidean,
-    #[pyo3(name = "haversine")]
     Haversine,
-    #[pyo3(name = "spheroid")]
     Spheroid,
 }
 

--- a/python/src/rtree/neighbors.rs
+++ b/python/src/rtree/neighbors.rs
@@ -2,11 +2,42 @@ use std::sync::Arc;
 
 use arrow_array::UInt32Array;
 use arrow_buffer::ScalarBuffer;
+use geo_index::rtree::distance::{DistanceMetric, EuclideanDistance, HaversineDistance, SpheroidDistance};
 use geo_index::rtree::RTreeIndex;
 use pyo3::prelude::*;
 use pyo3_arrow::PyArray;
 
 use crate::rtree::input::PyRTreeRef;
+
+#[derive(Debug, Clone)]
+#[pyclass(eq, eq_int)]
+#[derive(PartialEq, Eq)]
+pub enum PyDistanceMetric {
+    #[pyo3(name = "euclidean")]
+    Euclidean,
+    #[pyo3(name = "haversine")]
+    Haversine,
+    #[pyo3(name = "spheroid")]
+    Spheroid,
+}
+
+impl PyDistanceMetric {
+    fn to_metric_f32(&self) -> Box<dyn DistanceMetric<f32>> {
+        match self {
+            PyDistanceMetric::Euclidean => Box::new(EuclideanDistance),
+            PyDistanceMetric::Haversine => Box::new(HaversineDistance::default()),
+            PyDistanceMetric::Spheroid => Box::new(SpheroidDistance::default()),
+        }
+    }
+
+    fn to_metric_f64(&self) -> Box<dyn DistanceMetric<f64>> {
+        match self {
+            PyDistanceMetric::Euclidean => Box::new(EuclideanDistance),
+            PyDistanceMetric::Haversine => Box::new(HaversineDistance::default()),
+            PyDistanceMetric::Spheroid => Box::new(SpheroidDistance::default()),
+        }
+    }
+}
 
 #[pyfunction]
 #[pyo3(signature = (index, x, y, *, max_results = None, max_distance = None))]
@@ -26,6 +57,45 @@ pub fn neighbors(
             max_distance.map(|x| x as f32),
         ),
         PyRTreeRef::Float64(tree) => tree.neighbors(x, y, max_results, max_distance),
+    };
+    let results = UInt32Array::new(ScalarBuffer::from(results), None);
+    Ok(PyArray::from_array_ref(Arc::new(results))
+        .to_arro3(py)?
+        .unbind())
+}
+
+#[pyfunction]
+#[pyo3(signature = (index, x, y, distance_metric, *, max_results = None, max_distance = None))]
+pub fn neighbors_with_distance(
+    py: Python,
+    index: PyRTreeRef,
+    x: f64,
+    y: f64,
+    distance_metric: PyDistanceMetric,
+    max_results: Option<usize>,
+    max_distance: Option<f64>,
+) -> PyResult<PyObject> {
+    let results = match index {
+        PyRTreeRef::Float32(tree) => {
+            let metric = distance_metric.to_metric_f32();
+            tree.neighbors_with_distance(
+                x as f32,
+                y as f32,
+                max_results,
+                max_distance.map(|x| x as f32),
+                metric.as_ref(),
+            )
+        },
+        PyRTreeRef::Float64(tree) => {
+            let metric = distance_metric.to_metric_f64();
+            tree.neighbors_with_distance(
+                x,
+                y,
+                max_results,
+                max_distance,
+                metric.as_ref(),
+            )
+        },
     };
     let results = UInt32Array::new(ScalarBuffer::from(results), None);
     Ok(PyArray::from_array_ref(Arc::new(results))

--- a/python/tests/test_rtree.py
+++ b/python/tests/test_rtree.py
@@ -54,3 +54,57 @@ def test_partitions():
 
     assert np.all(np.asarray(indices) == np.arange(5))
     assert len(np.unique(np.asarray(partition_id))) == 3
+
+
+def test_neighbors():
+    """Test basic neighbors functionality"""
+    tree = create_index()
+    
+    # Test neighbors (backward compatibility)
+    result = rt.neighbors(tree, 0.0, 0.0, max_results=3)
+    assert len(result) <= 3
+    result_array = np.asarray(result)
+    # Should return indices in order of distance from (0,0)
+    assert result_array[0] == 0  # First item should be closest
+
+
+def test_neighbors_with_distance():
+    """Test neighbors with different distance metrics"""
+    tree = create_index()
+    
+    # Test with Euclidean distance
+    result_euclidean = rt.neighbors_with_distance(
+        tree, 0.0, 0.0, rt.PyDistanceMetric.Euclidean, max_results=3
+    )
+    assert len(result_euclidean) <= 3
+    
+    # Test with Haversine distance (should work for geographic coordinates)
+    result_haversine = rt.neighbors_with_distance(
+        tree, 0.0, 0.0, rt.PyDistanceMetric.Haversine, max_results=3
+    )
+    assert len(result_haversine) <= 3
+    
+    # Test with Spheroid distance
+    result_spheroid = rt.neighbors_with_distance(
+        tree, 0.0, 0.0, rt.PyDistanceMetric.Spheroid, max_results=3
+    )
+    assert len(result_spheroid) <= 3
+    
+    # Results should be similar for small distances (but order might vary)
+    euclidean_array = np.asarray(result_euclidean)
+    haversine_array = np.asarray(result_haversine)
+    spheroid_array = np.asarray(result_spheroid)
+    
+    # All should return the same number of results
+    assert len(euclidean_array) == len(haversine_array) == len(spheroid_array)
+
+
+def test_distance_metric_enum():
+    """Test that distance metric enum values work correctly"""
+    # Test enum values
+    assert rt.PyDistanceMetric.Euclidean == rt.PyDistanceMetric.Euclidean
+    assert rt.PyDistanceMetric.Haversine == rt.PyDistanceMetric.Haversine
+    assert rt.PyDistanceMetric.Spheroid == rt.PyDistanceMetric.Spheroid
+    
+    # Test that different enums are not equal
+    assert rt.PyDistanceMetric.Euclidean != rt.PyDistanceMetric.Haversine

--- a/src/rtree/distance.rs
+++ b/src/rtree/distance.rs
@@ -263,7 +263,7 @@ mod tests {
 
     #[test]
     fn test_spheroid_distance() {
-        let metric = SpheroidDistance::default();
+        let metric = SpheroidDistance;
         // Distance between New York and London (approximately)
         let distance = metric.distance(-74.0f64, 40.7f64, -0.1f64, 51.5f64);
         // Should be approximately 5585 km (slightly different from Haversine)

--- a/src/rtree/distance.rs
+++ b/src/rtree/distance.rs
@@ -4,16 +4,23 @@
 //! including Euclidean, Haversine, and Spheroid distance calculations.
 
 use crate::r#type::IndexableNum;
-use std::f64::consts::PI;
+use geo::algorithm::{Distance, Euclidean, Geodesic, Haversine};
+use geo::{Geometry, Point};
 
-/// A trait for calculating distances between two points.
+/// A trait for calculating distances between geometries and points.
 pub trait DistanceMetric<N: IndexableNum> {
     /// Calculate the distance between two points (x1, y1) and (x2, y2).
     fn distance(&self, x1: N, y1: N, x2: N, y2: N) -> N;
 
     /// Calculate the distance from a point to a bounding box.
-    /// This is used for spatial index optimization.
+    /// This is used for spatial index optimization during tree traversal.
     fn distance_to_bbox(&self, x: N, y: N, min_x: N, min_y: N, max_x: N, max_y: N) -> N;
+
+    /// Calculate the distance from a point to a geometry.
+    fn distance_to_geometry(&self, x: N, y: N, geometry: &Geometry<f64>) -> N;
+
+    /// Calculate the distance between two geometries.
+    fn geometry_to_geometry_distance(&self, geom1: &Geometry<f64>, geom2: &Geometry<f64>) -> N;
 
     /// Return the maximum distance value for this metric.
     fn max_distance(&self) -> N {
@@ -32,9 +39,9 @@ pub struct EuclideanDistance;
 impl<N: IndexableNum> DistanceMetric<N> for EuclideanDistance {
     #[inline]
     fn distance(&self, x1: N, y1: N, x2: N, y2: N) -> N {
-        let dx = x1 - x2;
-        let dy = y1 - y2;
-        (dx * dx + dy * dy).sqrt().unwrap_or(N::max_value())
+        let p1 = Point::new(x1.to_f64().unwrap_or(0.0), y1.to_f64().unwrap_or(0.0));
+        let p2 = Point::new(x2.to_f64().unwrap_or(0.0), y2.to_f64().unwrap_or(0.0));
+        N::from_f64(Euclidean.distance(p1, p2)).unwrap_or(N::max_value())
     }
 
     #[inline]
@@ -42,6 +49,18 @@ impl<N: IndexableNum> DistanceMetric<N> for EuclideanDistance {
         let dx = axis_dist(x, min_x, max_x);
         let dy = axis_dist(y, min_y, max_y);
         (dx * dx + dy * dy).sqrt().unwrap_or(N::max_value())
+    }
+
+    #[inline]
+    fn distance_to_geometry(&self, x: N, y: N, geometry: &Geometry<f64>) -> N {
+        let point = Point::new(x.to_f64().unwrap_or(0.0), y.to_f64().unwrap_or(0.0));
+        let point_geom = Geometry::Point(point);
+        N::from_f64(Euclidean.distance(&point_geom, geometry)).unwrap_or(N::max_value())
+    }
+
+    #[inline]
+    fn geometry_to_geometry_distance(&self, geom1: &Geometry<f64>, geom2: &Geometry<f64>) -> N {
+        N::from_f64(Euclidean.distance(geom1, geom2)).unwrap_or(N::max_value())
     }
 }
 
@@ -74,16 +93,9 @@ impl HaversineDistance {
 
 impl<N: IndexableNum> DistanceMetric<N> for HaversineDistance {
     fn distance(&self, lon1: N, lat1: N, lon2: N, lat2: N) -> N {
-        let lat1_rad = lat1.to_f64().unwrap_or(0.0) * PI / 180.0;
-        let lat2_rad = lat2.to_f64().unwrap_or(0.0) * PI / 180.0;
-        let delta_lat = (lat2.to_f64().unwrap_or(0.0) - lat1.to_f64().unwrap_or(0.0)) * PI / 180.0;
-        let delta_lon = (lon2.to_f64().unwrap_or(0.0) - lon1.to_f64().unwrap_or(0.0)) * PI / 180.0;
-
-        let a = (delta_lat / 2.0).sin().powi(2)
-            + lat1_rad.cos() * lat2_rad.cos() * (delta_lon / 2.0).sin().powi(2);
-        let c = 2.0 * a.sqrt().atan2((1.0 - a).sqrt());
-
-        N::from_f64(self.earth_radius * c).unwrap_or(N::max_value())
+        let p1 = Point::new(lon1.to_f64().unwrap_or(0.0), lat1.to_f64().unwrap_or(0.0));
+        let p2 = Point::new(lon2.to_f64().unwrap_or(0.0), lat2.to_f64().unwrap_or(0.0));
+        N::from_f64(Haversine.distance(p1, p2)).unwrap_or(N::max_value())
     }
 
     fn distance_to_bbox(
@@ -95,168 +107,71 @@ impl<N: IndexableNum> DistanceMetric<N> for HaversineDistance {
         max_lon: N,
         max_lat: N,
     ) -> N {
-        // For bbox distance with Haversine, we approximate using the closest point on the bbox
-        let closest_lon = if lon < min_lon {
-            min_lon
-        } else if lon > max_lon {
-            max_lon
-        } else {
-            lon
-        };
+        // For geographic distance to bbox, find the closest point on the bbox
+        let lon_f = lon.to_f64().unwrap_or(0.0);
+        let lat_f = lat.to_f64().unwrap_or(0.0);
+        let min_lon_f = min_lon.to_f64().unwrap_or(0.0);
+        let min_lat_f = min_lat.to_f64().unwrap_or(0.0);
+        let max_lon_f = max_lon.to_f64().unwrap_or(0.0);
+        let max_lat_f = max_lat.to_f64().unwrap_or(0.0);
 
-        let closest_lat = if lat < min_lat {
-            min_lat
-        } else if lat > max_lat {
-            max_lat
-        } else {
-            lat
-        };
+        let closest_lon = lon_f.clamp(min_lon_f, max_lon_f);
+        let closest_lat = lat_f.clamp(min_lat_f, max_lat_f);
 
-        self.distance(lon, lat, closest_lon, closest_lat)
+        let point = Point::new(lon_f, lat_f);
+        let closest_point = Point::new(closest_lon, closest_lat);
+        N::from_f64(Haversine.distance(point, closest_point)).unwrap_or(N::max_value())
+    }
+
+    fn distance_to_geometry(&self, lon: N, lat: N, geometry: &Geometry<f64>) -> N {
+        let point = Point::new(lon.to_f64().unwrap_or(0.0), lat.to_f64().unwrap_or(0.0));
+        // For Haversine, use point-to-centroid distance as approximation
+        match geometry {
+            Geometry::Point(p) => {
+                N::from_f64(Haversine.distance(point, *p)).unwrap_or(N::max_value())
+            }
+            _ => {
+                // For non-point geometries, use centroid
+                use geo::algorithm::Centroid;
+                if let Some(centroid) = geometry.centroid() {
+                    N::from_f64(Haversine.distance(point, centroid)).unwrap_or(N::max_value())
+                } else {
+                    N::max_value()
+                }
+            }
+        }
+    }
+
+    fn geometry_to_geometry_distance(&self, geom1: &Geometry<f64>, geom2: &Geometry<f64>) -> N {
+        // For Haversine, use centroid-to-centroid distance as approximation
+        use geo::algorithm::Centroid;
+        let centroid1 = geom1.centroid().unwrap_or(Point::new(0.0, 0.0));
+        let centroid2 = geom2.centroid().unwrap_or(Point::new(0.0, 0.0));
+        N::from_f64(Haversine.distance(centroid1, centroid2)).unwrap_or(N::max_value())
     }
 }
 
-/// Spheroid distance metric.
+/// Spheroid distance metric (using Geodesic/Vincenty's formula).
 ///
 /// This calculates the shortest distance between two points on the surface
 /// of a spheroid (ellipsoid), providing a more accurate Earth model than
 /// a simple sphere. The input coordinates should be in longitude/latitude
 /// (degrees), and the output distance is in meters.
-#[derive(Debug, Clone, Copy)]
-pub struct SpheroidDistance {
-    /// Semi-major axis (equatorial radius) in meters
-    pub semi_major_axis: f64,
-    /// Semi-minor axis (polar radius) in meters
-    pub semi_minor_axis: f64,
-}
-
-impl Default for SpheroidDistance {
-    fn default() -> Self {
-        Self {
-            semi_major_axis: 6378137.0,      // WGS84 equatorial radius
-            semi_minor_axis: 6356752.314245, // WGS84 polar radius
-        }
-    }
-}
+#[derive(Debug, Clone, Copy, Default)]
+pub struct SpheroidDistance;
 
 impl SpheroidDistance {
-    /// Create a new Spheroid distance metric with custom ellipsoid parameters.
-    pub fn with_ellipsoid(semi_major_axis: f64, semi_minor_axis: f64) -> Self {
-        Self {
-            semi_major_axis,
-            semi_minor_axis,
-        }
-    }
-
     /// Create a new Spheroid distance metric for GRS80 ellipsoid.
     pub fn grs80() -> Self {
-        Self {
-            semi_major_axis: 6378137.0,
-            semi_minor_axis: 6356752.314140,
-        }
+        Self
     }
 }
 
 impl<N: IndexableNum> DistanceMetric<N> for SpheroidDistance {
     fn distance(&self, lon1: N, lat1: N, lon2: N, lat2: N) -> N {
-        // Vincenty's formulae for distance on ellipsoid
-        let lat1 = match lat1.to_f64() {
-            Some(value) => value * PI / 180.0,
-            None => return N::zero(), // Return a default value if conversion fails
-        };
-        let lat2 = match lat2.to_f64() {
-            Some(value) => value * PI / 180.0,
-            None => return N::zero(),
-        };
-        let delta_lon = match (lon2.to_f64(), lon1.to_f64()) {
-            (Some(lon2_value), Some(lon1_value)) => (lon2_value - lon1_value) * PI / 180.0,
-            _ => return N::zero(),
-        };
-
-        let a = self.semi_major_axis;
-        let b = self.semi_minor_axis;
-        let f = (a - b) / a; // flattening
-
-        let u1 = ((1.0 - f) * lat1.tan()).atan();
-        let u2 = ((1.0 - f) * lat2.tan()).atan();
-
-        let sin_u1 = u1.sin();
-        let cos_u1 = u1.cos();
-        let sin_u2 = u2.sin();
-        let cos_u2 = u2.cos();
-
-        let mut lambda = delta_lon;
-        let mut lambda_prev;
-        let mut iter_limit = 100;
-
-        let (sin_sigma, cos_sigma, sigma, _sin_alpha, cos_sq_alpha, cos_2sigma_m) = loop {
-            let sin_lambda = lambda.sin();
-            let cos_lambda = lambda.cos();
-
-            let sin_sigma = ((cos_u2 * sin_lambda).powi(2)
-                + (cos_u1 * sin_u2 - sin_u1 * cos_u2 * cos_lambda).powi(2))
-            .sqrt();
-
-            if sin_sigma == 0.0 {
-                // Co-incident points
-                return N::zero();
-            }
-
-            let cos_sigma = sin_u1 * sin_u2 + cos_u1 * cos_u2 * cos_lambda;
-            let sigma = sin_sigma.atan2(cos_sigma);
-
-            let sin_alpha = cos_u1 * cos_u2 * sin_lambda / sin_sigma;
-            let cos_sq_alpha = 1.0 - sin_alpha * sin_alpha;
-
-            let cos_2sigma_m = if cos_sq_alpha == 0.0 {
-                0.0 // Equatorial line
-            } else {
-                cos_sigma - 2.0 * sin_u1 * sin_u2 / cos_sq_alpha
-            };
-
-            let c = f / 16.0 * cos_sq_alpha * (4.0 + f * (4.0 - 3.0 * cos_sq_alpha));
-
-            lambda_prev = lambda;
-            lambda = delta_lon
-                + (1.0 - c)
-                    * f
-                    * sin_alpha
-                    * (sigma
-                        + c * sin_sigma
-                            * (cos_2sigma_m
-                                + c * cos_sigma * (-1.0 + 2.0 * cos_2sigma_m * cos_2sigma_m)));
-
-            iter_limit -= 1;
-            if iter_limit == 0 || (lambda - lambda_prev).abs() < 1e-12 {
-                break (
-                    sin_sigma,
-                    cos_sigma,
-                    sigma,
-                    sin_alpha,
-                    cos_sq_alpha,
-                    cos_2sigma_m,
-                );
-            }
-        };
-
-        let u_sq = cos_sq_alpha * (a * a - b * b) / (b * b);
-        let big_a =
-            1.0 + u_sq / 16384.0 * (4096.0 + u_sq * (-768.0 + u_sq * (320.0 - 175.0 * u_sq)));
-        let big_b = u_sq / 1024.0 * (256.0 + u_sq * (-128.0 + u_sq * (74.0 - 47.0 * u_sq)));
-
-        let delta_sigma = big_b
-            * sin_sigma
-            * (cos_2sigma_m
-                + big_b / 4.0
-                    * (cos_sigma * (-1.0 + 2.0 * cos_2sigma_m * cos_2sigma_m)
-                        - big_b / 6.0
-                            * cos_2sigma_m
-                            * (-3.0 + 4.0 * sin_sigma * sin_sigma)
-                            * (-3.0 + 4.0 * cos_2sigma_m * cos_2sigma_m)));
-
-        let distance = b * big_a * (sigma - delta_sigma);
-
-        N::from_f64(distance).unwrap_or(N::max_value())
+        let p1 = Point::new(lon1.to_f64().unwrap_or(0.0), lat1.to_f64().unwrap_or(0.0));
+        let p2 = Point::new(lon2.to_f64().unwrap_or(0.0), lat2.to_f64().unwrap_or(0.0));
+        N::from_f64(Geodesic.distance(p1, p2)).unwrap_or(N::max_value())
     }
 
     fn distance_to_bbox(
@@ -268,24 +183,47 @@ impl<N: IndexableNum> DistanceMetric<N> for SpheroidDistance {
         max_lon: N,
         max_lat: N,
     ) -> N {
-        // For bbox distance with Spheroid, we approximate using the closest point on the bbox
-        let closest_lon = if lon < min_lon {
-            min_lon
-        } else if lon > max_lon {
-            max_lon
-        } else {
-            lon
-        };
+        // Similar to haversine, approximate using closest point on bbox
+        let lon_f = lon.to_f64().unwrap_or(0.0);
+        let lat_f = lat.to_f64().unwrap_or(0.0);
+        let min_lon_f = min_lon.to_f64().unwrap_or(0.0);
+        let min_lat_f = min_lat.to_f64().unwrap_or(0.0);
+        let max_lon_f = max_lon.to_f64().unwrap_or(0.0);
+        let max_lat_f = max_lat.to_f64().unwrap_or(0.0);
 
-        let closest_lat = if lat < min_lat {
-            min_lat
-        } else if lat > max_lat {
-            max_lat
-        } else {
-            lat
-        };
+        let closest_lon = lon_f.clamp(min_lon_f, max_lon_f);
+        let closest_lat = lat_f.clamp(min_lat_f, max_lat_f);
 
-        self.distance(lon, lat, closest_lon, closest_lat)
+        let point = Point::new(lon_f, lat_f);
+        let closest_point = Point::new(closest_lon, closest_lat);
+        N::from_f64(Geodesic.distance(point, closest_point)).unwrap_or(N::max_value())
+    }
+
+    fn distance_to_geometry(&self, lon: N, lat: N, geometry: &Geometry<f64>) -> N {
+        let point = Point::new(lon.to_f64().unwrap_or(0.0), lat.to_f64().unwrap_or(0.0));
+        // For Geodesic, use point-to-centroid distance as approximation
+        match geometry {
+            Geometry::Point(p) => {
+                N::from_f64(Geodesic.distance(point, *p)).unwrap_or(N::max_value())
+            }
+            _ => {
+                // For non-point geometries, use centroid
+                use geo::algorithm::Centroid;
+                if let Some(centroid) = geometry.centroid() {
+                    N::from_f64(Geodesic.distance(point, centroid)).unwrap_or(N::max_value())
+                } else {
+                    N::max_value()
+                }
+            }
+        }
+    }
+
+    fn geometry_to_geometry_distance(&self, geom1: &Geometry<f64>, geom2: &Geometry<f64>) -> N {
+        // For Geodesic, use centroid-to-centroid distance as approximation
+        use geo::algorithm::Centroid;
+        let centroid1 = geom1.centroid().unwrap_or(Point::new(0.0, 0.0));
+        let centroid2 = geom2.centroid().unwrap_or(Point::new(0.0, 0.0));
+        N::from_f64(Geodesic.distance(centroid1, centroid2)).unwrap_or(N::max_value())
     }
 }
 
@@ -304,6 +242,8 @@ fn axis_dist<N: IndexableNum>(k: N, min: N, max: N) -> N {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use geo::LineString;
+    use geo_types::coord;
 
     #[test]
     fn test_euclidean_distance() {
@@ -328,5 +268,43 @@ mod tests {
         let distance = metric.distance(-74.0f64, 40.7f64, -0.1f64, 51.5f64);
         // Should be approximately 5585 km (slightly different from Haversine)
         assert!((distance - 5585000.0f64).abs() < 50000.0f64);
+    }
+
+    #[test]
+    fn test_distance_to_geometry_point() {
+        let metric = EuclideanDistance;
+        let point_geom = Geometry::Point(Point::new(3.0, 4.0));
+        let distance: f64 = metric.distance_to_geometry(0.0f64, 0.0f64, &point_geom);
+        assert!((distance - 5.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_distance_to_geometry_linestring() {
+        let metric = EuclideanDistance;
+        let line_geom = Geometry::LineString(LineString::new(vec![
+            coord! { x: 0.0, y: 5.0 },
+            coord! { x: 10.0, y: 5.0 },
+        ]));
+        let distance: f64 = metric.distance_to_geometry(0.0f64, 0.0f64, &line_geom);
+        assert!((distance - 5.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_geometry_to_geometry_distance() {
+        let metric = EuclideanDistance;
+        let point1 = Geometry::Point(Point::new(0.0, 0.0));
+        let point2 = Geometry::Point(Point::new(3.0, 4.0));
+        let distance: f64 = metric.geometry_to_geometry_distance(&point1, &point2);
+        assert!((distance - 5.0).abs() < 1e-10);
+    }
+
+    #[test]
+    fn test_haversine_geometry_distance() {
+        let metric = HaversineDistance::default();
+        let ny_point = Geometry::Point(Point::new(-74.0, 40.7)); // New York
+        let london_point = Geometry::Point(Point::new(-0.1, 51.5)); // London
+        let distance: f64 = metric.geometry_to_geometry_distance(&ny_point, &london_point);
+        // Should be approximately 5585 km
+        assert!((distance - 5585000.0).abs() < 50000.0);
     }
 }

--- a/src/rtree/trait.rs
+++ b/src/rtree/trait.rs
@@ -605,7 +605,7 @@ mod test {
             builder.add(139.7, 35.7, 139.7, 35.7); // Tokyo
             let tree = builder.finish::<HilbertSort>();
 
-            let spheroid = SpheroidDistance::default();
+            let spheroid = SpheroidDistance;
             let results = tree.neighbors_with_distance(-74.0, 40.7, None, None, &spheroid);
 
             // From New York, should find New York first, then London, then Tokyo

--- a/src/rtree/trait.rs
+++ b/src/rtree/trait.rs
@@ -238,14 +238,10 @@ pub trait RTreeIndex<N: IndexableNum>: Sized {
                     }));
                 } else {
                     // leaf item (use odd id)
-                    // For leaf items, calculate distance to the center of the bounding box
-                    let center_x = (boxes[pos] + boxes[pos + 2]) / (N::one() + N::one());
-                    let center_y = (boxes[pos + 1] + boxes[pos + 3]) / (N::one() + N::one());
-                    let leaf_dist = distance_metric.distance(x, y, center_x, center_y);
-
+                    // Use consistent distance calculation for both nodes and leaf items
                     queue.push(Reverse(NeighborNode {
                         id: (index << 1) + 1,
-                        dist: leaf_dist,
+                        dist,
                     }));
                 }
             }


### PR DESCRIPTION
The implementation leverages the robust and well-tested geo crate for distance calculations, making the code much cleaner and more maintainable while providing more accurate spatial queries based on actual geometry shapes rather than just point to bounding boxes.

Extended DistanceMetric trait with two new methods:
- distance_to_geometry: Calculate distance from a point to any geometry type
- geometry_to_geometry_distance: Calculate distance between two geometries

Added new neighbors_geometry method to RTreeIndex trait:
- Accepts a query geometry (Point, LineString, Polygon, etc.)
- Takes a slice of geometries corresponding to the indexed items
- Uses actual geometry-to-geometry distance calculations for leaf items
- Falls back to bbox approximation for internal tree nodes during traversal
Smart distance calculation strategy:
- EuclideanDistance: Uses the geo crate's full geometry-to-geometry distance support
- HaversineDistance: For non-point geometries, uses centroid-to-centroid distance as approximation
- SpheroidDistance: Similar centroid-based approximation for complex geometries

Comprehensive testing with:
- Point-to-point geometry distances
- Point-to-LineString distances
- Geometry-to-geometry distances
- Mixed geometry type neighbor searches
- Geographic coordinate support with Haversine distances

Example code demonstrating real-world usage with:
- Point geometries
- Mixed geometry types (Points, LineStrings, Polygons)
- LineString-specific searches

